### PR TITLE
Prevent FalsePostives in Censor.go

### DIFF
--- a/censor.go
+++ b/censor.go
@@ -5,7 +5,7 @@ import (
 	goaway "github.com/TwiN/go-away"
 )
 
-var detector = goaway.NewProfanityDetector().WithSanitizeSpaces(false)
+var detector = goaway.NewProfanityDetector().WithSanitizeSpaces(false).WithWholeWordMatch(true)
 
 func rmBadWords(text string) string {
 	if !Config.Censor {


### PR DESCRIPTION
by adding .WithWholeWordMatch(true) the detector will only block bad words if there is a complete match.